### PR TITLE
Add welcome page with current time display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # codex-test
-Test repository for codex integration
+
+This repository hosts a simple static web page that welcomes visitors and displays the current local time on demand.
+
+## Project structure
+
+- `index.html` – A self-contained HTML page that shows a "Welcome" heading and a button. Clicking the button displays the visitor's current date and time using their device's locale and timezone settings.
+
+## Getting started
+
+1. Start a lightweight web server from the repository root (for example, using Python):
+   ```bash
+   python -m http.server 8000
+   ```
+2. Open your browser and navigate to [http://localhost:8000/](http://localhost:8000/).
+3. Click **Show Current Time** to see the date and time formatted for your locale.
+
+No build steps are required; the page runs entirely in the browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: linear-gradient(180deg, #f5f7fa 0%, #c3cfe2 100%);
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    main {
+      background-color: rgba(255, 255, 255, 0.9);
+      border-radius: 16px;
+      box-shadow: 0 20px 45px rgba(0, 0, 0, 0.12);
+      padding: 48px 56px;
+      text-align: center;
+      max-width: 480px;
+      width: calc(100% - 32px);
+    }
+
+    h1 {
+      margin: 0 0 24px;
+      font-size: 2.5rem;
+      color: #2d3748;
+    }
+
+    button {
+      border: none;
+      border-radius: 999px;
+      background-color: #2563eb;
+      color: #fff;
+      padding: 14px 32px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    button:hover,
+    button:focus {
+      outline: none;
+      background-color: #1d4ed8;
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(37, 99, 235, 0.4);
+    }
+
+    #time-display {
+      margin-top: 24px;
+      font-size: 1.25rem;
+      color: #1a202c;
+      min-height: 1.5em;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Welcome</h1>
+    <button id="show-time" type="button">
+      Show Current Time
+    </button>
+    <div id="time-display" role="status" aria-live="polite"></div>
+  </main>
+  <script>
+    const showTimeButton = document.getElementById('show-time');
+    const timeDisplay = document.getElementById('time-display');
+
+    function formatCurrentTime() {
+      const now = new Date();
+      const formatter = new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'full',
+        timeStyle: 'medium'
+      });
+      return formatter.format(now);
+    }
+
+    showTimeButton.addEventListener('click', () => {
+      timeDisplay.textContent = formatCurrentTime();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static `index.html` welcome page with a button to reveal the current local time
- style the page with a simple centered layout and accessible status region
- document how to serve and test the page in the README

## Testing
- manually opened http://127.0.0.1:8000/index.html and verified the time updates after clicking the button

------
https://chatgpt.com/codex/tasks/task_e_68db9e941bb08322860ca707e4510e2b