### PR TITLE
Add network fallback for quote of the day

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ This repository hosts a simple static web page that welcomes visitors, displays 
    python -m http.server 8000
    ```
 2. Open your browser and navigate to [http://localhost:8000/](http://localhost:8000/).
-3. Review the thought of the day automatically loaded from the internet.
+3. Review the thought of the day automatically loaded from the internet. The page first tries to fetch a quote from [DummyJSON's quote API](https://dummyjson.com/quotes/random) and, if that is unavailable, from [ZenQuotes](https://zenquotes.io/api/random). When both networks fail, an on-device quote is shown so the page still surfaces an uplifting thought.
 4. Click **Show Current Time** to see the date and time formatted for your locale.
 No build steps are required; the page runs entirely in the browser.

--- a/index.html
+++ b/index.html
@@ -130,24 +130,78 @@
       return formatter.format(now);
     }
 
-    async function fetchThoughtOfTheDay() {
-      try {
-        const response = await fetch('https://api.quotable.io/random?tags=inspirational|wisdom', {
-          cache: 'no-store'
-        });
+    const localQuotes = [
+      {
+        text: 'Take a deep breath and craft your own thought for today.',
+        author: ''
+      },
+      {
+        text: 'Momentum comes from choosing one small action and finishing it.',
+        author: 'Productivity proverb'
+      },
+      {
+        text: 'Your future self is already thankful for today\'s effort.',
+        author: 'Unknown'
+      }
+    ];
 
-        if (!response.ok) {
-          throw new Error(`Unexpected response: ${response.status}`);
+    function updateQuote({ text, author }, statusMessage = '') {
+      quoteText.textContent = text;
+      quoteAuthor.textContent = author ? `— ${author}` : '';
+      quoteStatus.textContent = statusMessage;
+    }
+
+    async function requestQuote(url, transform) {
+      const response = await fetch(url, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Unexpected response: ${response.status}`);
+      }
+      const data = await response.json();
+      return transform(data);
+    }
+
+    async function fetchThoughtOfTheDay() {
+      const providers = [
+        () => requestQuote('https://dummyjson.com/quotes/random', (data) => ({
+          text: data.quote,
+          author: data.author
+        })),
+        () => requestQuote('https://zenquotes.io/api/random', (data) => {
+          const [quote] = Array.isArray(data) ? data : [];
+          if (!quote || !quote.q) {
+            throw new Error('Unexpected payload shape');
+          }
+          return {
+            text: quote.q,
+            author: quote.a
+          };
+        })
+      ];
+
+      try {
+        for (const provider of providers) {
+          try {
+            const quote = await provider();
+            updateQuote(quote);
+            return;
+          } catch (error) {
+            // Try the next provider.
+          }
         }
 
-        const data = await response.json();
-        quoteText.textContent = data.content;
-        quoteAuthor.textContent = data.author ? `— ${data.author}` : '';
-        quoteStatus.textContent = '';
+        const fallbackQuote = localQuotes[Math.floor(Math.random() * localQuotes.length)];
+        updateQuote(
+          fallbackQuote,
+          'Showing one of our on-device favorites while we reconnect to the internet.'
+        );
       } catch (error) {
-        quoteText.textContent = 'Take a deep breath and craft your own thought for today.';
-        quoteAuthor.textContent = '';
-        quoteStatus.textContent = 'We could not fetch a quote from the internet right now. Please check your connection and refresh the page to try again.';
+        updateQuote(
+          {
+            text: 'Take a deep breath and craft your own thought for today.',
+            author: ''
+          },
+          'We could not fetch a quote from the internet right now. Please check your connection and refresh the page to try again.'
+        );
       } finally {
         quoteSection.setAttribute('aria-busy', 'false');
       }


### PR DESCRIPTION
## Summary
- chain quote fetching through DummyJSON and ZenQuotes before selecting a local fallback
- normalize quote responses and retain accessibility updates to the quote display
- document the primary and secondary quote sources and the on-device fallback in the README

## Testing
- Manual verification: refreshed the page multiple times while online to confirm quotes load from network providers
- Manual verification: blocked external quote requests to confirm the local fallback is rendered

------
https://chatgpt.com/codex/tasks/task_e_68dded1f11908322a9359518a5415c2d